### PR TITLE
Fix toast permission typo

### DIFF
--- a/app/src/main/java/com/uop/quizapp/MainActivity.java
+++ b/app/src/main/java/com/uop/quizapp/MainActivity.java
@@ -272,7 +272,7 @@ public class MainActivity extends AppCompatActivity{
             }
 
         }else {
-            Toast.makeText(this, "PERMITION DENIED", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "PERMISSION DENIED", Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
## Summary
- fix misspelled toast message in `MainActivity`

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Unsupported class file major version 65)*


------
https://chatgpt.com/codex/tasks/task_e_6859156b9d18832cb91377c468b9887c