### PR TITLE
Refactor to use in-memory Redis-style store

### DIFF
--- a/app/src/main/java/com/uop/quizapp/GameOver.java
+++ b/app/src/main/java/com/uop/quizapp/GameOver.java
@@ -38,7 +38,8 @@ public class GameOver extends AppCompatActivity {
 
     }
     private void initializing(){
-        isMute = getIntent().getExtras().getBoolean("isMute");
+        RedisManager db = RedisManager.getInstance();
+        isMute = db.get("isMute");
         final MediaPlayer win_sound = MediaPlayer.create(this,R.raw.win_sound);
         if (!isMute) {
             win_sound.start();
@@ -50,19 +51,18 @@ public class GameOver extends AppCompatActivity {
         team2Score_tv = findViewById(R.id.team2Score_tv);
         ImageView winning_im = findViewById(R.id.winning_im);
 
-        t1n = getIntent().getExtras().getString("team1Name");
-        t2n = getIntent().getExtras().getString("team2Name");
-        t1s = getIntent().getExtras().getInt("team1Score");
-        t2s = getIntent().getExtras().getInt("team2Score");
-        team1byte = getIntent().getExtras().getByteArray("team1byte");
-        team2byte = getIntent().getExtras().getByteArray("team2byte");
+        t1n = db.get("team1Name");
+        t2n = db.get("team2Name");
+        t1s = db.get("team1Score");
+        t2s = db.get("team2Score");
+        team1byte = db.get("team1byte");
+        team2byte = db.get("team2byte");
         //getting selected_language from SelectCategory.java
-        language = getIntent().getExtras().getString("selected_language");
-        score = getIntent().getExtras().getInt("score");
-        timeInSeconds = getIntent().getExtras().getInt("timeInSeconds");
+        language = db.get("selected_language");
+        score = db.get("score");
+        timeInSeconds = db.get("timeInSeconds");
         //getting the winning team's image
-        Bundle ex = getIntent().getExtras();
-        byte[] winning_byte = ex.getByteArray("winning_byte");
+        byte[] winning_byte = db.get("winning_byte");
         if (winning_byte != null) {
             Bitmap winning_image = BitmapFactory.decodeByteArray(winning_byte, 0, winning_byte.length);
             winning_im.setImageBitmap(winning_image);
@@ -117,23 +117,24 @@ public class GameOver extends AppCompatActivity {
             click_sound.start();
         }
         Intent intent = new Intent(GameOver.this, MainActivity.class);
-        intent.putExtra("restart_boolean",true);
-        intent.putExtra("selected_language", language);
-        intent.putExtra("timeInSeconds", timeInSeconds);
-        intent.putExtra("score", score);
-        intent.putExtra("isMute",isMute);
+        RedisManager db = RedisManager.getInstance();
+        db.put("restart_boolean", true);
+        db.put("selected_language", language);
+        db.put("timeInSeconds", timeInSeconds);
+        db.put("score", score);
+        db.put("isMute", isMute);
         if(t1n.equals("Ομάδα 1") || t1n.equals("Team 1")){
 
         }else {
-            intent.putExtra("t1n", t1n);
+            db.put("t1n", t1n);
         }
         if(t2n.equals("Ομάδα 2") || t2n.equals("Team 2")){
 
         }else {
-            intent.putExtra("t2n",t2n);
+            db.put("t2n", t2n);
         }
-        intent.putExtra("team1byte",team1byte);
-        intent.putExtra("team2byte",team2byte);
+        db.put("team1byte", team1byte);
+        db.put("team2byte", team2byte);
         startActivity(intent);
         finish();
     }

--- a/app/src/main/java/com/uop/quizapp/MainActivity.java
+++ b/app/src/main/java/com/uop/quizapp/MainActivity.java
@@ -185,50 +185,48 @@ public class MainActivity extends AppCompatActivity{
                         click_sound.start();
                     }
                     Intent intent = new Intent(MainActivity.this, SelectCategory.class);
-                    //pass team names and scores and playing team to SelectedCategory.class
-                    intent.putExtra("team1Name", t1n);
-                    intent.putExtra("team2Name", t2n);
-                    intent.putExtra("team1Score", 0);
-                    intent.putExtra("team2Score", 0);
-                    intent.putExtra("score", score);
-                    //team1 starts by default
-                    intent.putExtra("playing_team", t1n);
-                    // passing initialized 0 values for correct answered counters for each category for each team
-                    intent.putExtra("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
-                    intent.putExtra("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
-                    intent.putExtra("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
-                    intent.putExtra("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
-                    intent.putExtra("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
-                    intent.putExtra("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
-                    intent.putExtra("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
-                    intent.putExtra("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
-                    //pass the time in seconds
-                    intent.putExtra("timeInSeconds",timeInSeconds);
-                    intent.putExtra("lastChance",lastChance);
-                    intent.putExtra("isMute",isMute);
+                    // Store the initial game state in RedisManager instead of using Intent extras
+                    RedisManager db = RedisManager.getInstance();
+                    db.put("team1Name", t1n);
+                    db.put("team2Name", t2n);
+                    db.put("team1Score", 0);
+                    db.put("team2Score", 0);
+                    db.put("score", score);
+                    db.put("playing_team", t1n); // team1 starts by default
+                    db.put("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
+                    db.put("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
+                    db.put("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
+                    db.put("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
+                    db.put("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
+                    db.put("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
+                    db.put("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
+                    db.put("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
+                    db.put("timeInSeconds", timeInSeconds);
+                    db.put("lastChance", lastChance);
+                    db.put("isMute", isMute);
                     //passing the images of the teams to SelectedCategory.class
                     if (team1bitmap != null){
                         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                         team1bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
                         team1byte = bytes.toByteArray();
-                        intent.putExtra("team1byte",team1byte);
+                        db.put("team1byte", team1byte);
                     }else {
-                        intent.putExtra("team1byte", (byte[]) null);
+                        db.put("team1byte", null);
                     }
                     if (team2bitmap != null){
                         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                         team2bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
                         team2byte = bytes.toByteArray();
-                        intent.putExtra("team2byte",team2byte);
+                        db.put("team2byte", team2byte);
                     }else {
-                        intent.putExtra("team2byte", (byte[]) null);
+                        db.put("team2byte", null);
                     }
                         //here we check if the user selected language from Settings.java
                         if (language == null){
                             //English is the default language
-                            intent.putExtra("selected_language","English");
+                            db.put("selected_language","English");
                         }else {
-                            intent.putExtra("selected_language", language);
+                            db.put("selected_language", language);
                         }
                     startActivity(intent);
                     finish();
@@ -311,23 +309,24 @@ public class MainActivity extends AppCompatActivity{
             click_sound.start();
         }
         Intent intent = new Intent(MainActivity.this,Settings.class);
-        intent.putExtra("selected_language", language);
-        intent.putExtra("timeInSeconds", timeInSeconds);
-        intent.putExtra("questionsPerCategory", score);
-        intent.putExtra("isMute",isMute);
-        intent.putExtra("t1_et",team1_et.getText().toString());
-        intent.putExtra("t2_et",team2_et.getText().toString());
+        RedisManager db = RedisManager.getInstance();
+        db.put("selected_language", language);
+        db.put("timeInSeconds", timeInSeconds);
+        db.put("questionsPerCategory", score);
+        db.put("isMute", isMute);
+        db.put("t1_et", team1_et.getText().toString());
+        db.put("t2_et", team2_et.getText().toString());
         if (team1bitmap != null){
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team1bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
             team1byte = bytes.toByteArray();
-            intent.putExtra("team1byte",team1byte);
+            db.put("team1byte", team1byte);
         }
         if (team2bitmap != null){
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team2bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
             team2byte = bytes.toByteArray();
-            intent.putExtra("team2byte",team2byte);
+            db.put("team2byte", team2byte);
         }
         startActivity(intent);
     }

--- a/app/src/main/java/com/uop/quizapp/MainGame.java
+++ b/app/src/main/java/com/uop/quizapp/MainGame.java
@@ -260,45 +260,42 @@ public class MainGame extends AppCompatActivity {
         //check if team 1 reached first the 12
         if (t1s == score) {
             playing_team = t2n;
-            intent.putExtra("playing_team", playing_team);
-        } else{
-            intent.putExtra("playing_team", playing_team);
         }
-        intent.putExtra("team1Name", t1n);
-        intent.putExtra("team2Name", t2n);
-        intent.putExtra("team1Score", t1s);
-        intent.putExtra("team2Score", t2s);
-        intent.putExtra("score", score);
-        intent.putExtra("lastChance",lastChance);
-        // passing values for correct answered counters for each category for each team
-        intent.putExtra("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
-        intent.putExtra("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
-        intent.putExtra("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
-        intent.putExtra("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
-        intent.putExtra("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
-        intent.putExtra("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
-        intent.putExtra("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
-        intent.putExtra("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
-        //passing selected_language and time in seconds
-        intent.putExtra("selected_language",language);
-        intent.putExtra("isMute",isMute);
-        intent.putExtra("timeInSeconds", timeInSeconds);
+        RedisManager db = RedisManager.getInstance();
+        db.put("playing_team", playing_team);
+        db.put("team1Name", t1n);
+        db.put("team2Name", t2n);
+        db.put("team1Score", t1s);
+        db.put("team2Score", t2s);
+        db.put("score", score);
+        db.put("lastChance", lastChance);
+        db.put("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
+        db.put("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
+        db.put("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
+        db.put("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
+        db.put("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
+        db.put("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
+        db.put("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
+        db.put("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
+        db.put("selected_language", language);
+        db.put("isMute", isMute);
+        db.put("timeInSeconds", timeInSeconds);
         //passing the images back to SelectedCategory.class
         if (team1bitmap != null) {
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team1bitmap.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
             byte[] team1byte = bytes.toByteArray();
-            intent.putExtra("team1byte", team1byte);
+            db.put("team1byte", team1byte);
         } else {
-            intent.putExtra("team1byte", (byte[]) null);
+            db.put("team1byte", null);
         }
         if (team2bitmap != null) {
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team2bitmap.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
             byte[] team2byte = bytes.toByteArray();
-            intent.putExtra("team2byte", team2byte);
+            db.put("team2byte", team2byte);
         } else {
-            intent.putExtra("team2byte", (byte[]) null);
+            db.put("team2byte", null);
         }
         //we set visible this layout when the user clicks the incorrect button
         if (changing_team_layout.getVisibility() == View.VISIBLE){
@@ -336,33 +333,33 @@ public class MainGame extends AppCompatActivity {
         top = findViewById(R.id.top);
         TextView playing_team_tv = findViewById(R.id.playing_team_tv);
 
-        //pass selected category from SelectedCategory.class to MainGame.class
-        selectedCategory = getIntent().getExtras().getString("selectedCategory");
+        //pass selected category from SelectCategory.class to MainGame.class
+        RedisManager db = RedisManager.getInstance();
+        selectedCategory = db.get("selectedCategory");
 
         //playing team ,score and team names are
-        playing_team = getIntent().getExtras().getString("playing_team");
-        t1n = getIntent().getExtras().getString("team1Name");
-        t2n = getIntent().getExtras().getString("team2Name");
-        t1s = getIntent().getExtras().getInt("team1Score");
-        t2s = getIntent().getExtras().getInt("team2Score");
-        t1n = getIntent().getExtras().getString("team1Name");
-        score = getIntent().getExtras().getInt("score");
-        lastChance = getIntent().getExtras().getBoolean("lastChance");
+        playing_team = db.get("playing_team");
+        t1n = db.get("team1Name");
+        t2n = db.get("team2Name");
+        t1s = db.get("team1Score");
+        t2s = db.get("team2Score");
+        score = db.get("score");
+        lastChance = db.get("lastChance");
 
         //retrieving the values for correct answered counters for each category for each team
-        team1NationalCorrectAnswers = getIntent().getExtras().getInt("team1NationalCorrectAnswers");
-        team2NationalCorrectAnswers = getIntent().getExtras().getInt("team2NationalCorrectAnswers");
-        team1ClubsCorrectAnswers = getIntent().getExtras().getInt("team1ClubsCorrectAnswers");
-        team2ClubsCorrectAnswers = getIntent().getExtras().getInt("team2ClubsCorrectAnswers");
-        team1GeographyCorrectAnswers = getIntent().getExtras().getInt("team1GeographyCorrectAnswers");
-        team2GeographyCorrectAnswers = getIntent().getExtras().getInt("team2GeographyCorrectAnswers");
-        team1GeneralCorrectAnswers = getIntent().getExtras().getInt("team1GeneralCorrectAnswers");
-        team2GeneralCorrectAnswers = getIntent().getExtras().getInt("team2GeneralCorrectAnswers");
+        team1NationalCorrectAnswers = db.get("team1NationalCorrectAnswers");
+        team2NationalCorrectAnswers = db.get("team2NationalCorrectAnswers");
+        team1ClubsCorrectAnswers = db.get("team1ClubsCorrectAnswers");
+        team2ClubsCorrectAnswers = db.get("team2ClubsCorrectAnswers");
+        team1GeographyCorrectAnswers = db.get("team1GeographyCorrectAnswers");
+        team2GeographyCorrectAnswers = db.get("team2GeographyCorrectAnswers");
+        team1GeneralCorrectAnswers = db.get("team1GeneralCorrectAnswers");
+        team2GeneralCorrectAnswers = db.get("team2GeneralCorrectAnswers");
         //getting the selected_language from SelectCategory.java
-        language = getIntent().getExtras().getString("selected_language");
-        isMute = getIntent().getExtras().getBoolean("isMute");
+        language = db.get("selected_language");
+        isMute = db.get("isMute");
         //getting the time in seconds
-        timeInSeconds =  getIntent().getExtras().getInt("timeInSeconds");
+        timeInSeconds = db.get("timeInSeconds");
         if (playing_team.equals(t1n)) {
             playing_team_tv.setText(t1n);
         }else {
@@ -375,13 +372,11 @@ public class MainGame extends AppCompatActivity {
             show_hide_bt.setText("show");
         }
         //getting the images for the teams
-        Bundle ex = getIntent().getExtras();
-
-        byte[] team1byte = ex.getByteArray("team1byte");
+        byte[] team1byte = db.get("team1byte");
         if (team1byte != null) {
             team1bitmap = BitmapFactory.decodeByteArray(team1byte, 0, team1byte.length);
         }
-        byte[] team2byte = ex.getByteArray("team2byte");
+        byte[] team2byte = db.get("team2byte");
         if (team2byte != null) {
             team2bitmap = BitmapFactory.decodeByteArray(team2byte, 0, team2byte.length);
 

--- a/app/src/main/java/com/uop/quizapp/RedisManager.java
+++ b/app/src/main/java/com/uop/quizapp/RedisManager.java
@@ -1,0 +1,26 @@
+public class RedisManager {
+    private static RedisManager instance;
+    private final java.util.Map<String, Object> store = new java.util.HashMap<>();
+
+    private RedisManager() {}
+
+    public static synchronized RedisManager getInstance() {
+        if (instance == null) {
+            instance = new RedisManager();
+        }
+        return instance;
+    }
+
+    public synchronized void put(String key, Object value) {
+        store.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public synchronized <T> T get(String key) {
+        return (T) store.get(key);
+    }
+
+    public synchronized void clear() {
+        store.clear();
+    }
+}

--- a/app/src/main/java/com/uop/quizapp/SelectCategory.java
+++ b/app/src/main/java/com/uop/quizapp/SelectCategory.java
@@ -89,45 +89,43 @@ public class SelectCategory extends AppCompatActivity {
         }
         //pass selected category to MainGame.class
         Intent intent = new Intent(SelectCategory.this, MainGame.class);
-        intent.putExtra("selectedCategory", selectedCategory);
-        intent.putExtra("playing_team", playing_team);
-        intent.putExtra("team1Name",t1n);
-        intent.putExtra("team2Name",t2n);
-        intent.putExtra("team1Score",t1s);
-        intent.putExtra("team2Score",t2s);
-        intent.putExtra("score", score);
-        intent.putExtra("lastChance",lastChance);
-        // passing values for correct answered counters for each category for each team
-        intent.putExtra("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
-        intent.putExtra("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
-        intent.putExtra("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
-        intent.putExtra("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
-        intent.putExtra("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
-        intent.putExtra("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
-        intent.putExtra("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
-        intent.putExtra("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
-        //passing the language
-        intent.putExtra("selected_language",language);
-        intent.putExtra("isMute",isMute);
-        //passing the time in seconds
-        intent.putExtra("timeInSeconds",timeInSeconds);
+        RedisManager db = RedisManager.getInstance();
+        db.put("selectedCategory", selectedCategory);
+        db.put("playing_team", playing_team);
+        db.put("team1Name", t1n);
+        db.put("team2Name", t2n);
+        db.put("team1Score", t1s);
+        db.put("team2Score", t2s);
+        db.put("score", score);
+        db.put("lastChance", lastChance);
+        db.put("team1NationalCorrectAnswers", team1NationalCorrectAnswers);
+        db.put("team2NationalCorrectAnswers", team2NationalCorrectAnswers);
+        db.put("team1ClubsCorrectAnswers", team1ClubsCorrectAnswers);
+        db.put("team2ClubsCorrectAnswers", team2ClubsCorrectAnswers);
+        db.put("team1GeographyCorrectAnswers", team1GeographyCorrectAnswers);
+        db.put("team2GeographyCorrectAnswers", team2GeographyCorrectAnswers);
+        db.put("team1GeneralCorrectAnswers", team1GeneralCorrectAnswers);
+        db.put("team2GeneralCorrectAnswers", team2GeneralCorrectAnswers);
+        db.put("selected_language", language);
+        db.put("isMute", isMute);
+        db.put("timeInSeconds", timeInSeconds);
         //passing the images to MainGame.class
         if (team1bitmap != null){
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team1bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
             byte[] team1byte = bytes.toByteArray();
-            intent.putExtra("team1byte",team1byte);
+            db.put("team1byte", team1byte);
         }else {
-            intent.putExtra("team1byte", (byte[]) null);
+            db.put("team1byte", null);
         }
 
         if (team2bitmap != null){
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             team2bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
             byte[] team2byte = bytes.toByteArray();
-            intent.putExtra("team2byte",team2byte);
+            db.put("team2byte", team2byte);
         }else {
-            intent.putExtra("team2byte", (byte[]) null);
+            db.put("team2byte", null);
         }
 
 
@@ -164,23 +162,24 @@ public class SelectCategory extends AppCompatActivity {
         national_tv = findViewById(R.id.national_tv);
 
 
-        //take the team names and scores and playing team
-        t1n = getIntent().getExtras().getString("team1Name");
-        t2n = getIntent().getExtras().getString("team2Name");
-        t1s = getIntent().getExtras().getInt("team1Score");
-        t2s = getIntent().getExtras().getInt("team2Score");
-        score = getIntent().getExtras().getInt("score");
-        playing_team = getIntent().getExtras().getString("playing_team");
-        lastChance = getIntent().getExtras().getBoolean("lastChance");
+        //take the team names and scores and playing team from RedisManager
+        RedisManager db = RedisManager.getInstance();
+        t1n = db.get("team1Name");
+        t2n = db.get("team2Name");
+        t1s = db.get("team1Score");
+        t2s = db.get("team2Score");
+        score = db.get("score");
+        playing_team = db.get("playing_team");
+        lastChance = db.get("lastChance");
         //retrieving the values for correct answered counters for each category for each team
-        team1NationalCorrectAnswers =  getIntent().getExtras().getInt("team1NationalCorrectAnswers");
-        team2NationalCorrectAnswers =  getIntent().getExtras().getInt("team2NationalCorrectAnswers");
-        team1ClubsCorrectAnswers =  getIntent().getExtras().getInt("team1ClubsCorrectAnswers");
-        team2ClubsCorrectAnswers =  getIntent().getExtras().getInt("team2ClubsCorrectAnswers");
-        team1GeographyCorrectAnswers =  getIntent().getExtras().getInt("team1GeographyCorrectAnswers");
-        team2GeographyCorrectAnswers =  getIntent().getExtras().getInt("team2GeographyCorrectAnswers");
-        team1GeneralCorrectAnswers =  getIntent().getExtras().getInt("team1GeneralCorrectAnswers");
-        team2GeneralCorrectAnswers =  getIntent().getExtras().getInt("team2GeneralCorrectAnswers");
+        team1NationalCorrectAnswers =  db.get("team1NationalCorrectAnswers");
+        team2NationalCorrectAnswers =  db.get("team2NationalCorrectAnswers");
+        team1ClubsCorrectAnswers =  db.get("team1ClubsCorrectAnswers");
+        team2ClubsCorrectAnswers =  db.get("team2ClubsCorrectAnswers");
+        team1GeographyCorrectAnswers =  db.get("team1GeographyCorrectAnswers");
+        team2GeographyCorrectAnswers =  db.get("team2GeographyCorrectAnswers");
+        team1GeneralCorrectAnswers =  db.get("team1GeneralCorrectAnswers");
+        team2GeneralCorrectAnswers =  db.get("team2GeneralCorrectAnswers");
 
         //set the score to the score board
 
@@ -194,20 +193,19 @@ public class SelectCategory extends AppCompatActivity {
         team2_clubs.setText(team2ClubsCorrectAnswers + "/" + score/4);
 
         //getting the selected_language from MainActivity.java or from MainGame.java
-        language = getIntent().getExtras().getString("selected_language");
-        isMute = getIntent().getExtras().getBoolean("isMute");
+        language = db.get("selected_language");
+        isMute = db.get("isMute");
         //getting the time in seconds
-        timeInSeconds = getIntent().getExtras().getInt("timeInSeconds");
+        timeInSeconds = db.get("timeInSeconds");
         //getting the images for two teams
-        Bundle ex = getIntent().getExtras();
-        team1byte = ex.getByteArray("team1byte");
+        team1byte = db.get("team1byte");
         if (team1byte != null) {
             team1bitmap = BitmapFactory.decodeByteArray(team1byte, 0, team1byte.length);
             team1_im.setImageBitmap(team1bitmap);
         }else {
             team1_im.setImageDrawable(getResources().getDrawable(R.drawable.user_im));
         }
-        team2byte = ex.getByteArray("team2byte");
+        team2byte = db.get("team2byte");
         if (team2byte != null) {
             team2bitmap = BitmapFactory.decodeByteArray(team2byte, 0, team2byte.length);
             team2_im.setImageBitmap(team2bitmap);
@@ -333,42 +331,42 @@ public class SelectCategory extends AppCompatActivity {
     }
     private void GameEnd(){
         Intent intent = new Intent(SelectCategory.this, GameOver.class);
-        intent.putExtra("team1Name",t1n);
-        intent.putExtra("team2Name",t2n);
-        intent.putExtra("team1Score",t1s);
-        intent.putExtra("team2Score",t2s);
-        //passing selected_language
-        intent.putExtra("selected_language",language);
-        intent.putExtra("isMute",isMute);
-        intent.putExtra("score",score);
-        intent.putExtra("timeInSeconds",timeInSeconds);
-        intent.putExtra("team1byte",team1byte);
-        intent.putExtra("team2byte", team2byte);
+        RedisManager db = RedisManager.getInstance();
+        db.put("team1Name", t1n);
+        db.put("team2Name", t2n);
+        db.put("team1Score", t1s);
+        db.put("team2Score", t2s);
+        db.put("selected_language", language);
+        db.put("isMute", isMute);
+        db.put("score", score);
+        db.put("timeInSeconds", timeInSeconds);
+        db.put("team1byte", team1byte);
+        db.put("team2byte", team2byte);
         //passing the winning team image
         if (t1s > t2s){
             if (team1bitmap != null){
                 ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                 team1bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
                 team1byte = bytes.toByteArray();
-                intent.putExtra("winning_byte",team1byte);
+                db.put("winning_byte", team1byte);
             }else {
-                intent.putExtra("winning_byte", (byte[]) null);
+                db.put("winning_byte", null);
             }
         } else if (t1s == t2s) {
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             Bitmap bitmap = BitmapFactory.decodeResource(getResources(),R.drawable.draw);
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
             team1byte = bytes.toByteArray();
-            intent.putExtra("winning_byte",team1byte);
+            db.put("winning_byte", team1byte);
 
         } else {
             if (team2bitmap != null){
                 ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                 team2bitmap.compress(Bitmap.CompressFormat.JPEG, 100,bytes);
                 team2byte = bytes.toByteArray();
-                intent.putExtra("winning_byte",team2byte);
+                db.put("winning_byte", team2byte);
             }else {
-                intent.putExtra("winning_byte", (byte[]) null);
+                db.put("winning_byte", null);
             }
         }
         startActivity(intent);

--- a/app/src/main/java/com/uop/quizapp/Settings.java
+++ b/app/src/main/java/com/uop/quizapp/Settings.java
@@ -56,21 +56,21 @@ public class Settings extends AppCompatActivity {
         mute_bt = findViewById(R.id.mute_bt);
 
 
-        questionsPerCategory = getIntent().getExtras().getInt("questionsPerCategory") /4;
-        timeInSeconds = getIntent().getExtras().getInt("timeInSeconds");
-        language = getIntent().getExtras().getString("selected_language");
-        isMute = getIntent().getExtras().getBoolean("isMute");
-        t1_et = getIntent().getStringExtra("t1_et");
-        t2_et = getIntent().getStringExtra("t2_et");
+        RedisManager db = RedisManager.getInstance();
+        questionsPerCategory = ((Integer) db.get("questionsPerCategory")) /4;
+        timeInSeconds = db.get("timeInSeconds");
+        language = db.get("selected_language");
+        isMute = db.get("isMute");
+        t1_et = db.get("t1_et");
+        t2_et = db.get("t2_et");
 
         preselected_language = language;
         preselected_timeInSeconds = timeInSeconds;
         preselected_questionsPerCategory = questionsPerCategory;
         preselected_isMute = isMute;
 
-        Bundle ex = getIntent().getExtras();
-        team1byte = ex.getByteArray("team1byte");
-        team2byte = ex.getByteArray("team2byte");
+        team1byte = db.get("team1byte");
+        team2byte = db.get("team2byte");
 
 
         //Here we check if the user has already changed the setting and got back again, in this case we put the right values
@@ -167,17 +167,18 @@ public class Settings extends AppCompatActivity {
             click_sound.start();
         }
         Intent intent = new Intent(Settings.this, MainActivity.class);
-        intent.putExtra("selected_language", language);
-        intent.putExtra("timeInSeconds", timeInSeconds);
-        intent.putExtra("questionsPerCategory", questionsPerCategory);
-        intent.putExtra("isMute",isMute);
-        intent.putExtra("t1_et",t1_et);
-        intent.putExtra("t2_et",t2_et);
+        RedisManager db = RedisManager.getInstance();
+        db.put("selected_language", language);
+        db.put("timeInSeconds", timeInSeconds);
+        db.put("questionsPerCategory", questionsPerCategory);
+        db.put("isMute", isMute);
+        db.put("t1_et", t1_et);
+        db.put("t2_et", t2_et);
         if (team1byte != null){
-            intent.putExtra("team1byte", team1byte);
+            db.put("team1byte", team1byte);
         }
         if (team2byte != null){
-            intent.putExtra("team2byte", team2byte);
+            db.put("team2byte", team2byte);
         }
         startActivity(intent);
         finish();
@@ -186,17 +187,18 @@ public class Settings extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         Intent intent = new Intent(Settings.this, MainActivity.class);
-        intent.putExtra("selected_language", preselected_language);
-        intent.putExtra("timeInSeconds", preselected_timeInSeconds);
-        intent.putExtra("questionsPerCategory", preselected_questionsPerCategory);
-        intent.putExtra("isMute",preselected_isMute);
-        intent.putExtra("t1_et",t1_et);
-        intent.putExtra("t2_et",t2_et);
+        RedisManager db = RedisManager.getInstance();
+        db.put("selected_language", preselected_language);
+        db.put("timeInSeconds", preselected_timeInSeconds);
+        db.put("questionsPerCategory", preselected_questionsPerCategory);
+        db.put("isMute", preselected_isMute);
+        db.put("t1_et", t1_et);
+        db.put("t2_et", t2_et);
         if (team1byte != null){
-            intent.putExtra("team1byte", team1byte);
+            db.put("team1byte", team1byte);
         }
         if (team2byte != null){
-            intent.putExtra("team2byte", team2byte);
+            db.put("team2byte", team2byte);
         }
         startActivity(intent);
         finish();
@@ -207,17 +209,18 @@ public class Settings extends AppCompatActivity {
             click_sound.start();
         }
         Intent intent = new Intent(Settings.this, MainActivity.class);
-        intent.putExtra("selected_language", preselected_language);
-        intent.putExtra("timeInSeconds", preselected_timeInSeconds);
-        intent.putExtra("questionsPerCategory", preselected_questionsPerCategory);
-        intent.putExtra("isMute",preselected_isMute);
-        intent.putExtra("t1_et",t1_et);
-        intent.putExtra("t2_et",t2_et);
+        RedisManager db2 = RedisManager.getInstance();
+        db2.put("selected_language", preselected_language);
+        db2.put("timeInSeconds", preselected_timeInSeconds);
+        db2.put("questionsPerCategory", preselected_questionsPerCategory);
+        db2.put("isMute", preselected_isMute);
+        db2.put("t1_et", t1_et);
+        db2.put("t2_et", t2_et);
         if (team1byte != null){
-            intent.putExtra("team1byte", team1byte);
+            db2.put("team1byte", team1byte);
         }
         if (team2byte != null){
-            intent.putExtra("team2byte", team2byte);
+            db2.put("team2byte", team2byte);
         }
         startActivity(intent);
         finish();


### PR DESCRIPTION
## Summary
- introduce `RedisManager` as simple in-memory database
- store game state to `RedisManager` instead of using `Intent` extras
- read game state from `RedisManager` across activities

## Testing
- `./gradlew test --dry-run` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685957eb6f94832c840214882b1e9e47