### PR TITLE
Refactor repeated logic into utilities

### DIFF
--- a/app/src/main/java/com/uop/quizapp/util/BitmapUtils.java
+++ b/app/src/main/java/com/uop/quizapp/util/BitmapUtils.java
@@ -1,0 +1,41 @@
+package com.uop.quizapp.util;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Utility methods for converting between {@link Bitmap} and byte arrays.
+ */
+public final class BitmapUtils {
+    private BitmapUtils() {}
+
+    /**
+     * Convert a bitmap to a JPEG encoded byte array.
+     *
+     * @param bitmap Bitmap to convert, may be null.
+     * @return byte array or null if bitmap was null
+     */
+    public static byte[] toByteArray(Bitmap bitmap) {
+        if (bitmap == null) {
+            return null;
+        }
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
+        return bytes.toByteArray();
+    }
+
+    /**
+     * Decode a bitmap from the given byte array.
+     *
+     * @param data Image data, may be null.
+     * @return Decoded bitmap or null if data was null
+     */
+    public static Bitmap fromByteArray(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        return BitmapFactory.decodeByteArray(data, 0, data.length);
+    }
+}

--- a/app/src/main/java/com/uop/quizapp/util/DoubleBackPressExitHandler.java
+++ b/app/src/main/java/com/uop/quizapp/util/DoubleBackPressExitHandler.java
@@ -1,0 +1,33 @@
+package com.uop.quizapp.util;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
+/**
+ * Utility to handle double back press to exit behaviour for Activities.
+ */
+public class DoubleBackPressExitHandler {
+    private boolean doubleBackToExitPressedOnce;
+    private final Context context;
+
+    public DoubleBackPressExitHandler(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Call from {@link android.app.Activity#onBackPressed()}.
+     *
+     * @return true if the Activity should exit
+     */
+    public boolean onBackPressed() {
+        if (doubleBackToExitPressedOnce) {
+            return true;
+        }
+        doubleBackToExitPressedOnce = true;
+        Toast.makeText(context, "Please click BACK twice to exit", Toast.LENGTH_SHORT).show();
+        new Handler(Looper.getMainLooper()).postDelayed(() -> doubleBackToExitPressedOnce = false, 1000);
+        return false;
+    }
+}

--- a/app/src/main/java/com/uop/quizapp/util/SoundUtils.java
+++ b/app/src/main/java/com/uop/quizapp/util/SoundUtils.java
@@ -1,0 +1,25 @@
+package com.uop.quizapp.util;
+
+import android.content.Context;
+import android.media.MediaPlayer;
+
+/**
+ * Helper for playing short sound effects respecting mute state.
+ */
+public final class SoundUtils {
+    private SoundUtils() {}
+
+    /**
+     * Play the given sound resource if not muted.
+     * The created {@link MediaPlayer} is released automatically.
+     */
+    public static void play(Context context, int soundResId, boolean isMute) {
+        if (isMute) {
+            return;
+        }
+        MediaPlayer mp = MediaPlayer.create(context, soundResId);
+        if (mp == null) return;
+        mp.setOnCompletionListener(MediaPlayer::release);
+        mp.start();
+    }
+}

--- a/app/src/main/java/com/uop/quizapp/viewmodels/MainViewModel.java
+++ b/app/src/main/java/com/uop/quizapp/viewmodels/MainViewModel.java
@@ -7,7 +7,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.uop.quizapp.GameState;
 
-import java.io.ByteArrayOutputStream;
+import com.uop.quizapp.util.BitmapUtils;
 
 public class MainViewModel extends ViewModel {
     public GameState createInitialGameState(String team1Name,
@@ -38,14 +38,10 @@ public class MainViewModel extends ViewModel {
         gs.lastChance = lastChance;
         gs.isMute = isMute;
         if (team1bitmap != null) {
-            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-            team1bitmap.compress(CompressFormat.JPEG, 100, bytes);
-            gs.team1byte = bytes.toByteArray();
+            gs.team1byte = BitmapUtils.toByteArray(team1bitmap);
         }
         if (team2bitmap != null) {
-            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-            team2bitmap.compress(CompressFormat.JPEG, 100, bytes);
-            gs.team2byte = bytes.toByteArray();
+            gs.team2byte = BitmapUtils.toByteArray(team2bitmap);
         }
         gs.selectedLanguage = language == null ? "English" : language;
         return gs;

--- a/app/src/main/java/com/uop/quizapp/viewmodels/SelectCategoryViewModel.java
+++ b/app/src/main/java/com/uop/quizapp/viewmodels/SelectCategoryViewModel.java
@@ -6,8 +6,7 @@ import android.graphics.Bitmap.CompressFormat;
 import androidx.lifecycle.ViewModel;
 
 import com.uop.quizapp.GameState;
-
-import java.io.ByteArrayOutputStream;
+import com.uop.quizapp.util.BitmapUtils;
 
 /**
  * Helper ViewModel for preparing game state when a category is chosen.
@@ -22,14 +21,10 @@ public class SelectCategoryViewModel extends ViewModel {
         }
         gs.selectedCategory = selectedCategory;
         if (team1bitmap != null) {
-            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-            team1bitmap.compress(CompressFormat.JPEG, 100, bytes);
-            gs.team1byte = bytes.toByteArray();
+            gs.team1byte = BitmapUtils.toByteArray(team1bitmap);
         }
         if (team2bitmap != null) {
-            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-            team2bitmap.compress(CompressFormat.JPEG, 100, bytes);
-            gs.team2byte = bytes.toByteArray();
+            gs.team2byte = BitmapUtils.toByteArray(team2bitmap);
         }
         return gs;
     }


### PR DESCRIPTION
## Summary
- centralize sound playback in `SoundUtils`
- add `BitmapUtils` for bitmap/byte[] conversion
- implement `DoubleBackPressExitHandler` to handle double-back exit
- update activities and view models to use new utilities

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685aa79e1f94832cab5aac2601f6289e