### PR TITLE
Fix last chance game over logic

### DIFF
--- a/app/src/main/java/com/uop/quizapp/MainGame.java
+++ b/app/src/main/java/com/uop/quizapp/MainGame.java
@@ -215,14 +215,33 @@ public class MainGame extends AppCompatActivity {
             }
             // incorrect button clicked
         } else {
-            //if the incorrect button clicked then change playing team and play incorrect sound
+            // If the incorrect button was clicked
             if (time_int < 10000) {
                 ticking_sound.stop();
             }
             SoundUtils.play(this, R.raw.incorrect_sound, isMute);
             count.cancel();
 
-            //checks if team 2 lost in last chance
+            // When team 2 loses during their last chance the game should end
+            if (gs.team1Score >= gs.score && gs.lastChance && gs.playingTeam.equals(gs.team2Name)) {
+                gs.lastChance = false;
+                ActivityDataStore db = ActivityDataStore.getInstance();
+                if (team1bitmap != null) {
+                    gs.team1byte = BitmapUtils.toByteArray(team1bitmap);
+                } else {
+                    gs.team1byte = null;
+                }
+                if (team2bitmap != null) {
+                    gs.team2byte = BitmapUtils.toByteArray(team2bitmap);
+                } else {
+                    gs.team2byte = null;
+                }
+                db.setGameState(gs);
+                startActivity(intent);
+                return;
+            }
+
+            //checks if team 2 lost in a normal round
             if (!(gs.team1Score >= gs.score && gs.lastChance)){
                 if (gs.team1Score != gs.score) {
                     changing_team_layout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/uop/quizapp/SelectCategory.java
+++ b/app/src/main/java/com/uop/quizapp/SelectCategory.java
@@ -227,9 +227,11 @@ public class SelectCategory extends AppCompatActivity {
         team1_score_tv.setText(String.valueOf(gs.team1Score));
         team2_score_tv.setText(String.valueOf(gs.team2Score));
 
-        // if team 1 reach first the score the team 2 has one last chance
+        // if team 1 reached the target score the second team gets only one chance
         if (gs.team1Score >= score && lastChance){
             lastChance = false;
+            gs.lastChance = false;
+            db.setGameState(gs);
         } else if (gs.team2Score >= score) {
             GameEnd();
         } else if (gs.team1Score >= score) {


### PR DESCRIPTION
## Summary
- end the game when team 2 fails during their last chance
- persist lastChance state when handing over to the second team

## Testing
- `./gradlew test` *(fails: unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_685ab333a26c832ca25f70c591cccec8