### PR TITLE
Improve question loading speed

### DIFF
--- a/app/src/main/java/com/uop/quizapp/ActivityDataStore.java
+++ b/app/src/main/java/com/uop/quizapp/ActivityDataStore.java
@@ -1,5 +1,9 @@
 package com.uop.quizapp;
 
+import java.util.List;
+
+import com.uop.quizapp.Questions;
+
 /**
  * Singleton key-value store used to pass data between activities.
  */
@@ -53,5 +57,22 @@ public class ActivityDataStore {
      */
     public synchronized void setGameState(GameState gameState) {
         store.put("gameState", gameState);
+    }
+
+    /**
+     * Store a list of questions for the given category.
+     */
+    public synchronized void putQuestions(String category, java.util.List<Questions> qs) {
+        store.put("questions_" + category, qs);
+    }
+
+    /**
+     * Retrieve cached questions for the given category.
+     */
+    @SuppressWarnings("unchecked")
+    public synchronized java.util.List<Questions> getQuestions(String category) {
+        Object obj = store.get("questions_" + category);
+        if (obj == null) return null;
+        return (java.util.List<Questions>) obj;
     }
 }

--- a/app/src/main/java/com/uop/quizapp/viewmodels/MainGameViewModel.java
+++ b/app/src/main/java/com/uop/quizapp/viewmodels/MainGameViewModel.java
@@ -46,4 +46,11 @@ public class MainGameViewModel extends ViewModel {
             }
         });
     }
+
+    /**
+     * Persist the displayed state of a question.
+     */
+    public void markQuestionDisplayed(String categoryKey, Questions question) {
+        repository.updateQuestionDisplayed(categoryKey, question);
+    }
 }


### PR DESCRIPTION
## Summary
- add cached question storage to `ActivityDataStore`
- mark questions as displayed using a new method on `MainGameViewModel`
- fetch cached questions in `MainGame` before hitting Firebase
- prefetch a subset of questions at game start

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685ba4088a58832ca3fb9bf263070524