### PR TITLE
Store shown question ids locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ QuizApp is a team-based football trivia game built for Android devices. Two team
 * Scores per category are tracked so you can see each team's strengths.
 * At the end of the match a summary screen displays the winner and full statistics.
 
-The question database resides in Firebase Realtime Database. Each question has a `displayed` flag which is set to `true` once used so that questions are not repeated in a single game. A helper class resets these flags at game start.
+The question database resides in Firebase Realtime Database. Question IDs that have already been shown in the current session are tracked locally using `ActivityDataStore` so multiple devices can read from the same database without interfering with each other.
 
 ## Architecture
 The project is written in Java using Android Studio and Gradle. Important components include:

--- a/app/src/main/java/com/uop/quizapp/GameState.java
+++ b/app/src/main/java/com/uop/quizapp/GameState.java
@@ -1,6 +1,8 @@
 package com.uop.quizapp;
 
 import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
 
 public class GameState implements Serializable {
     public String team1Name;
@@ -24,4 +26,6 @@ public class GameState implements Serializable {
     public byte[] team1byte;
     public byte[] team2byte;
     public String selectedCategory;
+    // Tracks the questions shown for each category in the current session
+    public Map<String, Set<Integer>> displayedQuestionIds;
 }

--- a/app/src/main/java/com/uop/quizapp/MainActivity.java
+++ b/app/src/main/java/com/uop/quizapp/MainActivity.java
@@ -35,8 +35,6 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.uop.quizapp.ActivityDataStore;
-import com.uop.quizapp.repository.FirebaseQuestionRepository;
-import com.uop.quizapp.repository.QuestionRepository;
 
 
 import com.uop.quizapp.util.BitmapUtils;
@@ -77,9 +75,6 @@ public class MainActivity extends AppCompatActivity{
 
     }
     private void initializing(){
-        //reset all the displayed values to false in the data source
-        QuestionRepository repository = new FirebaseQuestionRepository();
-        repository.resetAllDisplayedValues();
         ActivityDataStore db = ActivityDataStore.getInstance();
 
         team1_et = findViewById(R.id.team1_et);

--- a/app/src/main/java/com/uop/quizapp/MainGame.java
+++ b/app/src/main/java/com/uop/quizapp/MainGame.java
@@ -141,7 +141,7 @@ public class MainGame extends AppCompatActivity {
         which_button = String.valueOf(view.getId());
         Intent intent = new Intent(MainGame.this, SelectCategory.class);
         if (which_button.equals(String.valueOf(correct_bt.getId()))) {
-            if (time_int < 10000) {
+            if (time_int < 10000 && ticking_sound != null) {
                 ticking_sound.stop();
             }
             if (gs.team2Score < gs.score - 1) {
@@ -216,7 +216,7 @@ public class MainGame extends AppCompatActivity {
             // incorrect button clicked
         } else {
             // If the incorrect button was clicked
-            if (time_int < 10000) {
+            if (time_int < 10000 && ticking_sound != null) {
                 ticking_sound.stop();
             }
             SoundUtils.play(this, R.raw.incorrect_sound, isMute);
@@ -327,6 +327,11 @@ public class MainGame extends AppCompatActivity {
         //pass selected category from SelectCategory.class to MainGame.class
         ActivityDataStore db = ActivityDataStore.getInstance();
         gs = db.getGameState();
+        if (gs == null) {
+            Toast.makeText(this, "Game state lost", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
         selectedCategory = gs.selectedCategory;
         language = gs.selectedLanguage;
         isMute = gs.isMute;

--- a/app/src/main/java/com/uop/quizapp/SelectCategory.java
+++ b/app/src/main/java/com/uop/quizapp/SelectCategory.java
@@ -88,6 +88,10 @@ public class SelectCategory extends AppCompatActivity {
         Intent intent = new Intent(SelectCategory.this, MainGame.class);
         ActivityDataStore db = ActivityDataStore.getInstance();
         gs = db.getGameState();
+        if (gs == null) {
+            Toast.makeText(this, "Game state lost", Toast.LENGTH_SHORT).show();
+            return;
+        }
         gs = viewModel.applySelectedCategory(gs, selectedCategory, team1bitmap, team2bitmap);
         db.setGameState(gs);
         startActivity(intent);
@@ -126,6 +130,11 @@ public class SelectCategory extends AppCompatActivity {
         //take the team names and scores and playing team from RedisManager
         ActivityDataStore db = ActivityDataStore.getInstance();
         gs = db.getGameState();
+        if (gs == null) {
+            Toast.makeText(this, "Game state lost", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
         score = gs.score;
         lastChance = gs.lastChance;
 

--- a/app/src/main/java/com/uop/quizapp/repository/FirebaseQuestionRepository.java
+++ b/app/src/main/java/com/uop/quizapp/repository/FirebaseQuestionRepository.java
@@ -42,22 +42,4 @@ public class FirebaseQuestionRepository implements QuestionRepository {
                     }
                 });
     }
-
-    @Override
-    public void updateQuestionDisplayed(String category, Questions question) {
-        rootRef.child("questions").child(category)
-                .child(String.valueOf(question.get_id()))
-                .child("displayed").setValue(question.getDisplayed());
-    }
-
-    @Override
-    public void resetAllDisplayedValues() {
-        rootRef.child("questions").get().addOnSuccessListener(snapshot -> {
-            for (DataSnapshot cat : snapshot.getChildren()) {
-                for (DataSnapshot q : cat.getChildren()) {
-                    q.getRef().child("displayed").setValue(false);
-                }
-            }
-        });
-    }
 }

--- a/app/src/main/java/com/uop/quizapp/repository/QuestionRepository.java
+++ b/app/src/main/java/com/uop/quizapp/repository/QuestionRepository.java
@@ -14,8 +14,4 @@ public interface QuestionRepository {
     }
 
     void getQuestionsByCategory(String category, QuestionsCallback callback);
-
-    void updateQuestionDisplayed(String category, Questions question);
-
-    void resetAllDisplayedValues();
 }

--- a/app/src/main/java/com/uop/quizapp/viewmodels/MainGameViewModel.java
+++ b/app/src/main/java/com/uop/quizapp/viewmodels/MainGameViewModel.java
@@ -2,12 +2,17 @@ package com.uop.quizapp.viewmodels;
 
 import androidx.lifecycle.ViewModel;
 
+import com.uop.quizapp.ActivityDataStore;
+import com.uop.quizapp.GameState;
 import com.uop.quizapp.Questions;
 import com.uop.quizapp.repository.FirebaseQuestionRepository;
 import com.uop.quizapp.repository.QuestionRepository;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 public class MainGameViewModel extends ViewModel {
     private final QuestionRepository repository;
@@ -33,10 +38,38 @@ public class MainGameViewModel extends ViewModel {
                     callback.onError();
                     return;
                 }
+
+                ActivityDataStore ds = ActivityDataStore.getInstance();
+                GameState gs = ds.getGameState();
+                Set<Integer> used = null;
+                if (gs != null) {
+                    used = gs.displayedQuestionIds.get(categoryKey);
+                }
+                if (used == null) {
+                    used = new HashSet<>();
+                }
+
+                List<Questions> available = new ArrayList<>();
+                for (Questions q : qs) {
+                    if (!used.contains(q.get_id())) {
+                        available.add(q);
+                    }
+                }
+
+                if (available.isEmpty()) {
+                    callback.onError();
+                    return;
+                }
+
                 Random random = new Random();
-                Questions randomQuestion = qs.get(random.nextInt(qs.size()));
-                randomQuestion.setDisplayed(true);
-                repository.updateQuestionDisplayed(categoryKey, randomQuestion);
+                Questions randomQuestion = available.get(random.nextInt(available.size()));
+
+                used.add(randomQuestion.get_id());
+                if (gs != null) {
+                    gs.displayedQuestionIds.put(categoryKey, used);
+                    ds.setGameState(gs);
+                }
+
                 callback.onLoaded(randomQuestion);
             }
 

--- a/app/src/main/java/com/uop/quizapp/viewmodels/MainViewModel.java
+++ b/app/src/main/java/com/uop/quizapp/viewmodels/MainViewModel.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap.CompressFormat;
 import androidx.lifecycle.ViewModel;
 
 import com.uop.quizapp.GameState;
+import java.util.HashMap;
 
 import com.uop.quizapp.util.BitmapUtils;
 
@@ -44,6 +45,7 @@ public class MainViewModel extends ViewModel {
             gs.team2byte = BitmapUtils.toByteArray(team2bitmap);
         }
         gs.selectedLanguage = language == null ? "English" : language;
+        gs.displayedQuestionIds = new HashMap<>();
         return gs;
     }
 }


### PR DESCRIPTION
## Summary
- stop writing `displayed` flag to Firebase
- track shown question ids in `GameState`
- pick questions that haven't already been shown
- cleanup unused repository methods
- update docs about new local tracking

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685bb44d4618832ca386bf216e2e838f